### PR TITLE
Resolved countdown bug

### DIFF
--- a/src/application/views/frontend/login_verify.php
+++ b/src/application/views/frontend/login_verify.php
@@ -1,4 +1,23 @@
 <form method="post">
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+        let countdown = 60; // Set the countdown starting time in seconds
+        const countdownTime = document.getElementById('countdown-time'); // The <strong> element inside the span
+        const resendLink = document.getElementById('resend-link'); // The resend link
+
+        // Update the countdown every second
+        const timerInterval = setInterval(() => {
+            countdown -= 1; // Decrement the countdown
+
+            // Check if the countdown has finished
+            if (countdown < 0) {
+                clearInterval(timerInterval); // Stop the countdown
+                resendLink.style.display = 'inline'; // Show the resend link
+            }
+        }, 1000); // Repeat every 1000 milliseconds (1 second)
+        });
+    </script>
+
     <div class="humanid-logo">
         <div class="humanid-logo__placement">
         <img src="<?php echo $app->logoUrls->thumbnail;?>" alt="<?php echo $app->name; ?>">
@@ -51,14 +70,14 @@
                     </div>
                 <?php } ?>
             </div>
-            <span class="timer-text verify-area timer" style="display: none;"><?php echo str_replace("{TIME}",'<strong>00:60</strong>',$lang->text->resend);?></span>
+          <span class="timer-text verify-area timer"><?php echo str_replace("{TIME}",'<strong id="countdown-time">00:60</strong>',$lang->text->resend);?></span>
             <input type="hidden" name="remaining" id="remaining">
             <div class="humanid-form-placement__link">
                 <div class="humanid-form-placement__link__wrapper">
                     <a href="<?php echo site_url('login?a='.$app->id.'&t='.$row['token'].'&lang='.$lang->id.'&priority_country='.$pc->code);?>" class="humanid-link-blue-light">
                         <?php echo $lang->try;?>
                     </a>
-                    <a href="<?php echo site_url('login/resend?a='.$app->id.'&t='.$row['token'].'&lang='.$lang->id);?>" class="humanid-link-blue-light"><?php echo $lang->resend;?></a>
+                    <a href="<?php echo site_url('login/resend?a='.$app->id.'&t='.$row['token'].'&lang='.$lang->id);?>" id="resend-link" class="humanid-link-blue-light" style="display: none;"><?php echo $lang->resend;?></a>
                     <!--<a href="<?php /*echo base_url('recovery/new_number') */?>" class="humanid-link-blue-light">Recover Existing Account</a>-->
                 </div>
             </div>

--- a/src/application/views/frontend/login_verify.php
+++ b/src/application/views/frontend/login_verify.php
@@ -9,12 +9,16 @@
         const timerInterval = setInterval(() => {
             countdown -= 1; // Decrement the countdown
 
-            // Check if the countdown has finished
-            if (countdown < 0) {
-                clearInterval(timerInterval); // Stop the countdown
-                resendLink.style.display = 'inline'; // Show the resend link
-            }
-        }, 1000); // Repeat every 1000 milliseconds (1 second)
+                // Check if the countdown has finished
+                if (countdown == 0) {
+                    countdownTime.textContent = "00:00"; // Set the countdown to 00:00
+                }
+                // Pause one second to let the countdown display disappear before showing resend link
+                if (countdown < 0) {
+                    clearInterval(timerInterval); // Stop the countdown
+                    resendLink.style.display = 'inline'; // Show the resend link
+                }
+            }, 1000); // Repeat every 1000 milliseconds (1 second)
         });
     </script>
 
@@ -70,7 +74,7 @@
                     </div>
                 <?php } ?>
             </div>
-          <span class="timer-text verify-area timer"><?php echo str_replace("{TIME}",'<strong id="countdown-time">00:60</strong>',$lang->text->resend);?></span>
+          <span class="timer-text verify-area timer"><?php echo str_replace("{TIME}",'<strong id="countdown-time">01:00</strong>',$lang->text->resend);?></span>
             <input type="hidden" name="remaining" id="remaining">
             <div class="humanid-form-placement__link">
                 <div class="humanid-form-placement__link__wrapper">


### PR DESCRIPTION
Implemented some changes to resolve the countdown bug. At the time, the style of the count-down item was set to "display: none". This was changed with the help of a small script to appropriately show the countdown clock after a code has been sent and then show the "Resend Code" link only after the 60 seconds are up.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Implemented a JavaScript countdown timer on the login verification page, showcasing a resend link post countdown completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->