### PR TITLE
[TN-333] Protect Weblogin from automated attack

### DIFF
--- a/src/application/config/config.php
+++ b/src/application/config/config.php
@@ -530,3 +530,8 @@ $config['rewrite_short_tags'] = FALSE;
 | Array:		array('10.0.1.200', '192.168.5.0/24')
 */
 $config['proxy_ips'] = '';
+
+$aesSecretKey = $_ENV['AES_SECRET_KEY'];
+if(empty($aesSecretKey)) {
+    throw new Exception('AES Secret Key environment variable must be set');
+}

--- a/src/application/config/humanid.php
+++ b/src/application/config/humanid.php
@@ -9,4 +9,5 @@ $config['humanid'] = [
     'server_id' => $_ENV['HUMANID_SERVER_ID'] ?? '',
     'server_secret' => $_ENV['HUMANID_SERVER_SECRET'] ?? '',
     'protocol' => $_ENV['PROTOCOL'] ?? 'http',
+    'aes_secret_key' => $_ENV['AES_SECRET_KEY'] ?? '',
 ];

--- a/src/application/controllers/BaseController.php
+++ b/src/application/controllers/BaseController.php
@@ -11,6 +11,7 @@ class BaseController extends MY_Controller
     protected const ERR_EMAIL_RECOVERY_NOT_SETUP = 'ERR_34'; // Account Recovery has not been set-up
     protected const ERR_INVALID_EMAIL = 'ERR_35'; // Invalid email for account recovery
     protected const JWT_EXPIRED = 'jwt expired';
+    protected const GENERAL_ERROR = 'GENERAL_ERROR';
 
     protected const ERR_CANCELLED = 'CANCELLED';
     protected const MESSAGE_CANCELLED = 'Log-in is cancelled by User';

--- a/src/application/controllers/Home.php
+++ b/src/application/controllers/Home.php
@@ -12,6 +12,13 @@ class Home extends BaseController
 
     public function error()
     {
+        $errorCode = $this->input->get("errorCode");
+        if($errorCode) {
+            $this->data['error_message'] = "Something went wrong!";
+            $this->render();
+            return;
+        }
+
         $modal = $this->session->flashdata('modal');
         if ($modal) {
             $this->data['modal'] = $modal;

--- a/src/application/controllers/Login.php
+++ b/src/application/controllers/Login.php
@@ -31,8 +31,7 @@ class Login extends BaseController
         if ($this->form_validation->run() == TRUE) {
             // Request OTP
             $ip = $this->input->ip_address();
-            $encryptedIp = aes_encrypt_gcm($ip, hex2bin($this->humanid->getAesSecretKey()));
-            $encodedEncryptedIp = urlencode($encryptedIp);
+            $encodedEncryptedIp = $this->humanid->encryptIp($ip);
             $response = $this->humanid->userRequestOTP($dialcode, $phone, $webLoginToken, $this->_app->source, $encodedEncryptedIp, $this->lg->id, $requestId);
             if (!$response->success) {
                 $this->handleErrorRequestOtpLogin($response);
@@ -347,8 +346,7 @@ class Login extends BaseController
         $dialcode = $session['dialcode'];
         // Request OTP
         $ip = $this->input->ip_address();
-        $encryptedIp = aes_encrypt_gcm($ip, hex2bin($this->humanid->getAesSecretKey()));
-        $encodedEncryptedIp = urlencode($encryptedIp);
+        $encodedEncryptedIp = $this->humanid->encryptIp($ip);
         $response = $this->humanid->userRequestOTP($dialcode, $phone, $loginToken, $this->_app->source, $encodedEncryptedIp, $this->lg->id, $requestId);
         if (!$response->success) {
             $this->handleErrorRequestOtpLogin($response);

--- a/src/application/controllers/Login.php
+++ b/src/application/controllers/Login.php
@@ -30,7 +30,10 @@ class Login extends BaseController
 
         if ($this->form_validation->run() == TRUE) {
             // Request OTP
-            $response = $this->humanid->userRequestOTP($dialcode, $phone, $webLoginToken, $this->_app->source, $this->lg->id, $requestId);
+            $ip = $this->input->ip_address();
+            $encryptedIp = aes_encrypt_gcm($ip, hex2bin($this->humanid->getAesSecretKey()));
+            $encodedEncryptedIp = urlencode($encryptedIp);
+            $response = $this->humanid->userRequestOTP($dialcode, $phone, $webLoginToken, $this->_app->source, $encodedEncryptedIp, $this->lg->id, $requestId);
             if (!$response->success) {
                 $this->handleErrorRequestOtpLogin($response);
             }
@@ -96,7 +99,12 @@ class Login extends BaseController
         }
 
         $this->session->set_flashdata('modal', $modal);
-        $this->session->set_flashdata('error_message', $this->lg->error->tokenExpired);
+        if($response->code === self::GENERAL_ERROR) {
+            redirect(site_url('error?lang=' . $this->lg->id . "&errorCode=1"));
+            return;
+        } else {
+            $this->session->set_flashdata('error_message', $this->lg->error->tokenExpired);
+        }
         redirect(site_url('error?lang=' . $this->lg->id));
     }
 
@@ -338,7 +346,10 @@ class Login extends BaseController
         $phone = $session['phone'];
         $dialcode = $session['dialcode'];
         // Request OTP
-        $response = $this->humanid->userRequestOTP($dialcode, $phone, $loginToken, $this->_app->source, $this->lg->id, $requestId);
+        $ip = $this->input->ip_address();
+        $encryptedIp = aes_encrypt_gcm($ip, hex2bin($this->humanid->getAesSecretKey()));
+        $encodedEncryptedIp = urlencode($encryptedIp);
+        $response = $this->humanid->userRequestOTP($dialcode, $phone, $loginToken, $this->_app->source, $encodedEncryptedIp, $this->lg->id, $requestId);
         if (!$response->success) {
             $this->handleErrorRequestOtpLogin($response);
         }

--- a/src/application/helpers/helpers_helper.php
+++ b/src/application/helpers/helpers_helper.php
@@ -14,3 +14,56 @@ if (! function_exists('dd')) {
         die;
     }
 }
+
+if (!function_exists('aes_encrypt_ccm')) {
+    function aes_encrypt_ccm($plaintext, $key, $aad = "") {
+        $ivlen = 12; // recommended IV length for AES-CCM
+        $taglen = 16; // tag length (can be 4, 6, 8, 10, 12, 14, or 16)
+        $iv = random_bytes($ivlen);
+
+        $cipher = 'aes-256-gcm';
+
+        $tag = null;
+        $ciphertext = openssl_encrypt(
+            $plaintext,
+            $cipher,
+            $key,
+            OPENSSL_RAW_DATA,
+            $iv,
+            $tag,
+            $aad,
+            $taglen
+        );
+
+        if ($ciphertext === false) {
+            return false;
+        }
+
+        return base64_encode($iv . $tag . $ciphertext);
+    }
+}
+
+if (!function_exists('aes_decrypt_ccm')) {
+    function aes_decrypt_ccm($encrypted, $key, $aad = '') {
+        $cipher = 'aes-256-ccm';
+        $ivlen = 12;
+        $taglen = 16;
+
+        $data = base64_decode($encrypted);
+        $iv = substr($data, 0, $ivlen);
+        $tag = substr($data, $ivlen, $taglen);
+        $ciphertext = substr($data, $ivlen + $taglen);
+
+        $plaintext = openssl_decrypt(
+            $ciphertext,
+            $cipher,
+            $key,
+            OPENSSL_RAW_DATA,
+            $iv,
+            $tag,
+            $aad
+        );
+
+        return $plaintext;
+    }
+}

--- a/src/application/helpers/helpers_helper.php
+++ b/src/application/helpers/helpers_helper.php
@@ -15,9 +15,9 @@ if (! function_exists('dd')) {
     }
 }
 
-if (!function_exists('aes_encrypt_ccm')) {
-    function aes_encrypt_ccm($plaintext, $key, $aad = "") {
-        $ivlen = 12; // recommended IV length for AES-CCM
+if (!function_exists('aes_encrypt_gcm')) {
+    function aes_encrypt_gcm($plaintext, $key, $aad = "") {
+        $ivlen = 12; // recommended IV length for AES-GCM
         $taglen = 16; // tag length (can be 4, 6, 8, 10, 12, 14, or 16)
         $iv = random_bytes($ivlen);
 
@@ -43,9 +43,9 @@ if (!function_exists('aes_encrypt_ccm')) {
     }
 }
 
-if (!function_exists('aes_decrypt_ccm')) {
-    function aes_decrypt_ccm($encrypted, $key, $aad = '') {
-        $cipher = 'aes-256-ccm';
+if (!function_exists('aes_decrypt_gcm')) {
+    function aes_decrypt_gcm($encrypted, $key, $aad = '') {
+        $cipher = 'aes-256-gcm';
         $ivlen = 12;
         $taglen = 16;
 

--- a/src/application/helpers/helpers_helper.php
+++ b/src/application/helpers/helpers_helper.php
@@ -42,28 +42,3 @@ if (!function_exists('aes_encrypt_gcm')) {
         return base64_encode($iv . $tag . $ciphertext);
     }
 }
-
-if (!function_exists('aes_decrypt_gcm')) {
-    function aes_decrypt_gcm($encrypted, $key, $aad = '') {
-        $cipher = 'aes-256-gcm';
-        $ivlen = 12;
-        $taglen = 16;
-
-        $data = base64_decode($encrypted);
-        $iv = substr($data, 0, $ivlen);
-        $tag = substr($data, $ivlen, $taglen);
-        $ciphertext = substr($data, $ivlen + $taglen);
-
-        $plaintext = openssl_decrypt(
-            $ciphertext,
-            $cipher,
-            $key,
-            OPENSSL_RAW_DATA,
-            $iv,
-            $tag,
-            $aad
-        );
-
-        return $plaintext;
-    }
-}

--- a/src/application/libraries/Humanid.php
+++ b/src/application/libraries/Humanid.php
@@ -39,9 +39,24 @@ class Humanid
         ]);
     }
 
-    public function getAesSecretKey()
+    public function encryptIp($ip)
     {
-        return $this->aes_secret_key;
+        if(empty($this->aes_secret_key)) {
+            throw new Exception('AES Secret Key environment variable must be set');
+        }
+
+        if($ip === false || empty($ip)) {
+            throw new Exception('IP is not set');
+        }
+
+        $encryptedIp = aes_encrypt_gcm($ip, hex2bin($this->aes_secret_key));
+        if($encryptedIp === false) {
+            throw new Exception('Failed to encrypt IP');
+        }
+
+        $encodedEncryptedIp = urlencode($encryptedIp);
+
+        return $encodedEncryptedIp;
     }
 
     public function getAppInfo($appId, $source = 'w')

--- a/src/application/libraries/Humanid.php
+++ b/src/application/libraries/Humanid.php
@@ -18,6 +18,7 @@ class Humanid
     private $server_id;
     private $server_secret;
     private $client;
+    private $aes_secret_key;
 
     function __construct()
     {
@@ -30,11 +31,17 @@ class Humanid
         $this->webLoginClientSecret = $humanIdConfig['client_secret'];
         $this->server_id = $humanIdConfig['server_id'];
         $this->server_secret = $humanIdConfig['server_secret'];
+        $this->aes_secret_key = $humanIdConfig['aes_secret_key'];
 
         $this->client = new Client([
             'base_uri' => $this->url,
             'timeout' => 10
         ]);
+    }
+
+    public function getAesSecretKey()
+    {
+        return $this->aes_secret_key;
     }
 
     public function getAppInfo($appId, $source = 'w')
@@ -121,7 +128,7 @@ class Humanid
         return $res;
     }
 
-    public function userRequestOTP($countryCode, $phone, $requestOtpToken, $source, $lang = 'en', $requestId = null)
+    public function userRequestOTP($countryCode, $phone, $requestOtpToken, $source, $ip, $lang = 'en', $requestId = null)
     {
         $url = $this->url. 'web-login/users/request-otp';
         $body = [
@@ -132,6 +139,7 @@ class Humanid
         $param = [
             'lang' => $lang,
             's' => $source,
+            'ip' => $ip
         ];
         // Handle RequestId
         if ($requestId !== null) {


### PR DESCRIPTION
[[TN-333] Issue](https://github.com/human-internet/humanid-weblogin/issues/65#issuecomment-2813623679)

This PR fixes the TN-333 ticket by adding several features below in the weblogin service:
1. AES encryption, to encrypt the `ip` query params sent to the core service.
2. AES_SECRET_KEY env value.
3. General error message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced AES-256-GCM encryption for enhanced data security.
  - Added support for encrypting and transmitting the client's IP address during OTP requests.

- **Bug Fixes**
  - Improved error handling and user feedback during OTP login and error scenarios.

- **Chores**
  - Updated configuration to support a new AES secret key.
  - Enforced presence of AES secret key environment variable at startup.
  - Enhanced internal error code management for more robust error processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->