### PR TITLE
fix: show rate limiting error display in phone number input screen ra…

### DIFF
--- a/src/application/controllers/Login.php
+++ b/src/application/controllers/Login.php
@@ -112,12 +112,11 @@ class Login extends BaseController
         }
 
         $this->session->set_flashdata('modal', $modal);
+
         if($response->code === self::GENERAL_ERROR) {
-            redirect(site_url('error?lang=' . $this->lg->id . "&errorCode=1"));
             return;
-        } else {
-            $this->session->set_flashdata('error_message', $this->lg->error->tokenExpired);
         }
+
         redirect(site_url('error?lang=' . $this->lg->id));
     }
 


### PR DESCRIPTION
…ther than error screen

This commit fix error showing because of rate limiting code from the core in the phone number input screen, rather than previously showing it in the separated error screen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for OTP login by consistently redirecting to a generic error page for certain error scenarios. Specialized redirects and flash error messages are no longer used for general errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->